### PR TITLE
Issue #27: stop setting deny message inside hook_tfa_skip_require

### DIFF
--- a/tfa_basic.info
+++ b/tfa_basic.info
@@ -3,7 +3,7 @@ description = "TFA plugins for Time-based One Time Passwords, Trusted Browsers, 
 backdrop = 1.x
 type = module
 
-dependencies[] = tfa (>= 1.x-2.2.0)
+dependencies[] = tfa (>=2.3.0)
 
 package = User Accounts
 tags[] = Account Management

--- a/tfa_basic.module
+++ b/tfa_basic.module
@@ -299,6 +299,13 @@ function tfa_basic_tfa_skip_require($account) {
 }
 
 /**
+ * Implements hook_tfa_login_denied().
+ */
+function tfa_basic_tfa_login_denied($account) {
+  tfa_basic_require_verification_message();
+}
+
+/**
  * Whether TFA requirement can be skipped for the account.
  *
  * @param User $account
@@ -321,7 +328,6 @@ function tfa_basic_skip_required($account) {
   }
   else {
     $skipped = FALSE;
-    tfa_basic_require_verification_message();
   }
 
   return $skipped;


### PR DESCRIPTION
Fixes #27.

Drops `tfa_basic_require_verification_message()` from inside `tfa_basic_skip_required()` — a `hook_tfa_skip_require` implementation must not set messages, because they fire even when a peer implementation grants the bypass.

Adds `tfa_basic_tfa_login_denied()` implementing the new `hook_tfa_login_denied` from backdrop-contrib/tfa#22, so the message still fires at the actual deny site for the common single-plugin case.

Depends on backdrop-contrib/tfa#23 landing first. Until both PRs merge, this PR alone would silently drop the "Login disallowed" message (no functional break, just no user-facing explanation when login is denied).